### PR TITLE
Users should be able to view all property adverts

### DIFF
--- a/controllers/adverts.js
+++ b/controllers/adverts.js
@@ -56,3 +56,8 @@ exports.createAdvert = (req, res) => {
     },
   });
 };
+
+exports.allAdverts = (req, res) => res.status(200).json({
+  status: 200,
+  data: adverts,
+});

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,12 +1,13 @@
 const router = require('express').Router();
 const signupController = require('../controllers/signup');
 const signinController = require('../controllers/signin');
-const createAdvertController = require('../controllers/createAdvert');
+const advertController = require('../controllers/adverts');
 const middleware = require('../middleware');
 
 router.route('/auth/signup').post(signupController.signup);
 router.route('/auth/signup').get(signupController.allUsers);
 router.route('/auth/signin').post(signinController.signin);
-router.route('/property').post(middleware.verifyToken, createAdvertController.createAdvert);
+router.route('/property').post(middleware.verifyToken, advertController.createAdvert);
+router.route('/property').get(advertController.allAdverts);
 
 module.exports = router;

--- a/test/advert.js
+++ b/test/advert.js
@@ -80,5 +80,17 @@ describe.only('Create an advert ', () => {
             });
         });
     });
+
+    it('should return all adverts in an array', (done) => {
+      chai.request(BASE_URL)
+        .get('/property')
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.should.be.a('object');
+          res.body.should.have.property('status');
+          res.body.should.have.property('data');
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
#### What does this PR do?
- Users should be able to view all property adverts
#### Description of Task to be completed?
- create an endpoint that returns all property adverts
#### How should this be manually tested?
- `git checkout ft-all-adverts-167009229` 
- hit this endpoint `http://localhost:5000/api/v1/property`
#### What are the relevant pivotal tracker stories?
- [#167009229](https://www.pivotaltracker.com/story/show/167009229)
#### Screenshots (if appropriate)
![Screenshot (37)](https://user-images.githubusercontent.com/39625835/60431303-22430600-9c08-11e9-9c81-29987cf9c288.png)

